### PR TITLE
the Small edit in Pseudo-code of a scalable inverted indexing algorithm in MapReduce

### DIFF
--- a/ed1n/chapter4-indexing.tex
+++ b/ed1n/chapter4-indexing.tex
@@ -489,7 +489,7 @@ information).
     \EndProcedure
     \Procedure{Reduce}{$\textrm{tuple }\langle t, n \rangle, \textrm{tf }[ f ]$}
     \If{$t \ne t_{prev} \land t_{prev} \ne \emptyset$}
-      \State $\textsc{Emit}(\textrm{term }t, \textrm{ postings } P)$
+      \State $\textsc{Emit}(\textrm{term }t_{prev}, \textrm{ postings } P)$
       \State $P.\textsc{{\small Reset}}()$
     \EndIf
     \State $P.\textsc{{\small Add}}(\langle n, f \rangle)$


### PR DESCRIPTION
When the reducer receives a term that wasn't seen before, it should emit the old term (t_{prev}) not the new one (t).
