### PR TITLE
Fix typo in scalable inverted indexing algorithm

### DIFF
--- a/ed1n/chapter4-indexing.tex
+++ b/ed1n/chapter4-indexing.tex
@@ -502,7 +502,7 @@ document id in the reducer.
     \State $t_{prev} \gets t$
     \EndProcedure
     \Procedure{Close}{}
-      \State $\textsc{Emit}(\textrm{term }t, \textrm{ postings } P)$
+      \State $\textsc{Emit}(t_{prev}, \textrm{ postings } P)$
     \EndProcedure
     \EndFunction
   \end{algorithmic}


### PR DESCRIPTION
The `t_{prev}` variable of the class should be emitted in the reducer's cleanup
method instead of `term t` which is only scoped within the Reduce function.
As noted by a student on the bigdata2018w Piazza.